### PR TITLE
Fixes Bug with check type for set variables

### DIFF
--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -328,7 +328,7 @@ Blockly.Blocks['variables_get'] = {
       }
     }else{
         this.setColour(Blockly.Blocks.shapes.HUE);
-        this.setOutput(true, "Number");
+        this.setOutput(true, type);
         this.attribute = shapeDropDowns[type][0][0];
     }  
   },


### PR DESCRIPTION
set variable blocks were allowing `Number` types as inputs (most likely
a typo). this commit makes checktype the selected type for that variable