### PR TITLE
Organizes all math blocks into single category.

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -442,7 +442,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyTreeSeparator {',
-    'border-bottom: solid #e5e5e5 1px;',
+    'border-bottom: solid #000000 1px;',
     'height: 0;',
     'margin: 5px 0;',
   '}',

--- a/tests/custom_playground.html
+++ b/tests/custom_playground.html
@@ -508,8 +508,10 @@ h1 {
       <block type="vpython_helix"></block>
              
     </category>
-    
-    <category name="Vector">
+
+<!-- ************************************************************* -->
+
+    <category name="Math">
       <block type="vector">
         <value name="X">
           <shadow type="math_number">
@@ -527,14 +529,6 @@ h1 {
           </shadow>
         </value>
       </block>
-
-      <block type="vector_math"></block>
-      
-    </category>
-
-<!-- ************************************************************* -->
-
-    <category name="Arithmetics">
       <block type="math_number" gap="32"></block>
       <block type="math_arithmetic">
         <value name="A">
@@ -548,6 +542,7 @@ h1 {
           </shadow>
         </value>
       </block>
+      <block type="vector_math"></block>
       <block type="math_modulo">
         <value name="DIVIDEND">
           <shadow type="math_number">
@@ -560,9 +555,9 @@ h1 {
           </shadow>
         </value>
       </block>
-    </category>
 
-    <category name="Math">
+      <sep></sep>
+
       <block type="math_single">
         <value name="NUM">
           <shadow type="math_number">
@@ -648,8 +643,7 @@ h1 {
         <value name="COLOUR">
           <shadow type=colour_picker></shadow>
         </value>
-      </block>
-      
+      </block>      
     </category>
 
     <category name="Text">

--- a/tests/custom_playground.html
+++ b/tests/custom_playground.html
@@ -511,7 +511,7 @@ h1 {
 
 <!-- ************************************************************* -->
 
-    <category name="Math">
+    <category name="Vector">
       <block type="vector">
         <value name="X">
           <shadow type="math_number">
@@ -529,6 +529,12 @@ h1 {
           </shadow>
         </value>
       </block>
+
+      <block type="vector_math"></block>
+
+    </category>
+
+    <category name="Math">
       <block type="math_number" gap="32"></block>
       <block type="math_arithmetic">
         <value name="A">
@@ -542,7 +548,7 @@ h1 {
           </shadow>
         </value>
       </block>
-      <block type="vector_math"></block>
+
       <block type="math_modulo">
         <value name="DIVIDEND">
           <shadow type="math_number">
@@ -555,8 +561,6 @@ h1 {
           </shadow>
         </value>
       </block>
-
-      <sep></sep>
 
       <block type="math_single">
         <value name="NUM">

--- a/trinket.xml
+++ b/trinket.xml
@@ -35,9 +35,7 @@
 
   </category>
 
-<!-- ************************************************************* -->
-
-  <category name="Arithmetics">
+  <category name="Math">
     <block type="math_number" gap="32"></block>
     <block type="math_arithmetic">
       <value name="A">
@@ -51,6 +49,7 @@
         </shadow>
       </value>
     </block>
+
     <block type="math_modulo">
       <value name="DIVIDEND">
         <shadow type="math_number">
@@ -63,9 +62,7 @@
         </shadow>
       </value>
     </block>
-  </category>
 
-  <category name="Math">
     <block type="math_single">
       <value name="NUM">
         <shadow type="math_number">
@@ -73,15 +70,15 @@
         </shadow>
       </value>
     </block>
-    <block type="math_random_float"></block>
     <block type="math_trig">
       <value name="NUM">
         <shadow type="math_number">
           <field name="NUM">45</field>
         </shadow>
       </value>
-    </block>
+    </block> 
     <block type="math_constant"></block>
+    <block type="math_random_float"></block>
     <block type="math_number_property">
       <value name="NUMBER_TO_CHECK">
         <shadow type="math_number">


### PR DESCRIPTION
Fixes #36.
Attempted to add a tree separator (using `<sep>` and utilizing blocklyTreeSeparator) however it appears tree separators are only available for use in the main category toolbox and not the flyout toolbox