### PR TITLE
Fixes #75

### DIFF
--- a/tests/custom_playground.html
+++ b/tests/custom_playground.html
@@ -623,15 +623,39 @@ h1 {
           </shadow>
         </value>
       </block>
+
       <block type="math_trig">
         <value name="NUM">
-          <shadow type="math_number">
-            <field name="NUM">45</field>
+          <shadow type="radian_degree">
+            <value name="NUM">
+              <shadow type="math_number">
+                <field name="NUM">45</field>
+              </shadow>
+            </value>
+          </shadow>
+        </value>
+      </block>
+
+      <block type="math_trig">
+        <value name="NUM">
+          <shadow type="math_arithmetic">
+            <field name="op_list">MULTIPLY</field>
+            <value name="A">
+              <shadow type="math_constant"></shadow>
+            </value>
+            <value name="B">
+              <shadow type="math_number">
+                <field name="NUM">2.5</field>
+              </shadow>
+            </value>
           </shadow>
         </value>
       </block> 
+
       <block type="math_constant"></block>
+
       <block type="math_random_float"></block>
+
       <block type="math_number_property">
         <value name="NUMBER_TO_CHECK">
           <shadow type="math_number">
@@ -639,6 +663,7 @@ h1 {
           </shadow>
         </value>
       </block>
+
       <block type="math_round">
         <value name="NUM">
           <shadow type="math_number">
@@ -646,7 +671,9 @@ h1 {
           </shadow>
         </value>
       </block>
+
       <block type="radian_degree"></block>
+
     </category>
 
     <category name="Loops">


### PR DESCRIPTION
Creates the shadow blocks for default inputs on the trig blocks for both a `radian()` and a `pi * 2.5`