### PR TITLE
Adds markers for highlighting and disableInitVariables option.

### DIFF
--- a/generators/python.js
+++ b/generators/python.js
@@ -151,7 +151,9 @@ Blockly.Python.init = function(workspace) {
     defvars[i] = Blockly.Python.variableDB_.getName(variables[i],
         Blockly.Variables.NAME_TYPE) + ' = None';
   }
-  Blockly.Python.definitions_['variables'] = defvars.join('\n');
+  if (!Blockly.Python.disableInitVariables_) {
+    Blockly.Python.definitions_['variables'] = defvars.join('\n');
+  }
 };
 
 /**
@@ -242,9 +244,27 @@ Blockly.Python.scrub_ = function(block, code) {
       }
     }
   }
+  code = commentCode + code;
+  if (Blockly.Python.mapBlocks_) {
+    var lines = code.split('\n');
+    var lastline = lines[lines.length - 1];
+
+    if (/^  \//.test(lastline)) {
+      lastline = lastline.substring(2, lastline.length);
+      lines[lines.length - 1] = lastline;
+    }
+    code = lines.join('\n');
+
+    var startTag = '/** ' + block.id + ' **/';
+    var endTag   = '/** end ' + block.id + ' **/';
+
+    // ensure endTag comes before any final newlines
+    code = code.replace(/(\n*)$/, endTag + "$1");
+    code = startTag + code;
+  }
   var nextBlock = block.nextConnection && block.nextConnection.targetBlock();
   var nextCode = Blockly.Python.blockToCode(nextBlock);
-  return commentCode + code + nextCode;
+  return code + nextCode;
 };
 
 /**


### PR DESCRIPTION
For consideration...

Updates the python generator code to add "block markers" for highlighting. This is copied verbatim from the code we added to our fork of blockly.

Also included (but we haven't discussed this as a group yet) is an option to disable all the "var = None" statements that blockly adds. We've enabled this within trinket for blocks.