### PR TITLE
82 series input

### DIFF
--- a/blocks/graphs.js
+++ b/blocks/graphs.js
@@ -8,11 +8,11 @@ Blockly.Blocks.graphs.HUE = '#26A69A';
 
 Blockly.Blocks['series'] = {
   init: function() {
-    this.appendDummyInput()
+    this.appendValueInput("COLOR")
+        .setCheck('Vector')
         .appendField(new Blockly.FieldDropdown([["curve", "CURVE"],
         										["dots", "DOTS"]]), "TYPE")
-        .appendField(new Blockly.FieldColour("#ff0000"), "COLOR");
-    this.setInputsInline(true);
+    this.setInputsInline(false);
     this.setOutput(true, "Series");
     this.setColour(Blockly.Blocks.graphs.HUE);
     this.setTooltip('Creates a series for plotting on a graph as either a solid\

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -73,13 +73,13 @@ Blockly.Mutator.prototype.drawIcon_ = function(group) {
   // Horizontal Cross Bar.
   Blockly.createSvgElement('rect',
       {'class': 'blocklyIconShape',
-       'x': '3.5', 'y': '7.9',
-       'height': '1', 'width': '9'},
+       'x': '3.75', 'y': '7.7',
+       'height': '1', 'width': '8.5'},
        group);
   // Vertical Cross Bar.
   Blockly.createSvgElement('rect',
       {'class': 'blocklyIconShape',
-       'x': '7.3', 'y': '4',
+       'x': '7.4', 'y': '4',
        'height': '8.5', 'width': '1'},
        group);
 };

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -70,14 +70,17 @@ Blockly.Mutator.prototype.drawIcon_ = function(group) {
        'rx': '4', 'ry': '4',
        'height': '16', 'width': '16'},
        group);
-  // Gear teeth.
-  Blockly.createSvgElement('path',
-      {'class': 'blocklyIconSymbol',
-       'd': 'm4.203,7.296 0,1.368 -0.92,0.677 -0.11,0.41 0.9,1.559 0.41,0.11 1.043,-0.457 1.187,0.683 0.127,1.134 0.3,0.3 1.8,0 0.3,-0.299 0.127,-1.138 1.185,-0.682 1.046,0.458 0.409,-0.11 0.9,-1.559 -0.11,-0.41 -0.92,-0.677 0,-1.366 0.92,-0.677 0.11,-0.41 -0.9,-1.559 -0.409,-0.109 -1.046,0.458 -1.185,-0.682 -0.127,-1.138 -0.3,-0.299 -1.8,0 -0.3,0.3 -0.126,1.135 -1.187,0.682 -1.043,-0.457 -0.41,0.11 -0.899,1.559 0.108,0.409z'},
+  // Horizontal Cross Bar.
+  Blockly.createSvgElement('rect',
+      {'class': 'blocklyIconShape',
+       'x': '3.5', 'y': '7.9',
+       'height': '1', 'width': '9'},
        group);
-  // Axle hole.
-  Blockly.createSvgElement('circle',
-      {'class': 'blocklyIconShape', 'r': '2.7', 'cx': '8', 'cy': '8'},
+  // Vertical Cross Bar.
+  Blockly.createSvgElement('rect',
+      {'class': 'blocklyIconShape',
+       'x': '7.3', 'y': '4',
+       'height': '8.5', 'width': '1'},
        group);
 };
 

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -70,17 +70,14 @@ Blockly.Mutator.prototype.drawIcon_ = function(group) {
        'rx': '4', 'ry': '4',
        'height': '16', 'width': '16'},
        group);
-  // Horizontal Cross Bar.
-  Blockly.createSvgElement('rect',
-      {'class': 'blocklyIconShape',
-       'x': '3.75', 'y': '7.7',
-       'height': '1', 'width': '8.5'},
+  // Gear teeth.
+  Blockly.createSvgElement('path',
+      {'class': 'blocklyIconSymbol',
+       'd': 'm4.203,7.296 0,1.368 -0.92,0.677 -0.11,0.41 0.9,1.559 0.41,0.11 1.043,-0.457 1.187,0.683 0.127,1.134 0.3,0.3 1.8,0 0.3,-0.299 0.127,-1.138 1.185,-0.682 1.046,0.458 0.409,-0.11 0.9,-1.559 -0.11,-0.41 -0.92,-0.677 0,-1.366 0.92,-0.677 0.11,-0.41 -0.9,-1.559 -0.409,-0.109 -1.046,0.458 -1.185,-0.682 -0.127,-1.138 -0.3,-0.299 -1.8,0 -0.3,0.3 -0.126,1.135 -1.187,0.682 -1.043,-0.457 -0.41,0.11 -0.899,1.559 0.108,0.409z'},
        group);
-  // Vertical Cross Bar.
-  Blockly.createSvgElement('rect',
-      {'class': 'blocklyIconShape',
-       'x': '7.4', 'y': '4',
-       'height': '8.5', 'width': '1'},
+  // Axle hole.
+  Blockly.createSvgElement('circle',
+      {'class': 'blocklyIconShape', 'r': '2.7', 'cx': '8', 'cy': '8'},
        group);
 };
 

--- a/generators/python/graphs.js
+++ b/generators/python/graphs.js
@@ -7,12 +7,10 @@ goog.require('Blockly.Python');
 Blockly.Python['series'] = function(block) {
   var code = 'g';
   var type = block.getFieldValue('TYPE');
-  var color = block.getFieldValue('COLOR');
-  var R = hexToR(color);
-  var G = hexToG(color);
-  var B = hexToB(color);
-  code = code + type.toLowerCase() + '(color=vector('
-  		 + R + '/255, ' + G + '/255, ' + B + '/255))';
+  var color = Blockly.Python.valueToCode(block, 'COLOR',
+      Blockly.Python.ORDER_NONE) || '\'\'';
+  code = code + type.toLowerCase() + '(color='
+  		 + color + ')';
 
   return [code, Blockly.Python.ORDER_ATOMIC];
 };

--- a/tests/custom_playground.html
+++ b/tests/custom_playground.html
@@ -517,16 +517,24 @@ h1 {
           <block type="variables_set">
             <field name="VAR">series1</field>
               <value name="VALUE">
-                <block type="series"></block>
-              <value>
+                <block type="series">
+                  <value name="COLOR">
+                    <shadow type="colour_picker"></shadow>
+                  </value>
+                </block>
+              </value>
           </block>
         </value>
       </block>
       <block type="variables_set">
         <field name="VAR">series</field>
-          <value name="VALUE">
-            <block type="series"></block>
-          <value>
+        <value name="VALUE">
+          <block type="series">
+            <value name="COLOR">
+              <shadow type="colour_picker"></shadow>
+            </value>
+          </block>
+        <value>
       </block>
       <block type="plot">
         <value name="X_VALUE">
@@ -737,7 +745,7 @@ h1 {
       <block type="texture_picker"></block>
       <block type="scene_colour">
         <value name="COLOUR">
-          <shadow type=colour_picker></shadow>
+          <shadow type="colour_picker"></shadow>
         </value>
       </block>      
     </category>

--- a/trinket.xml
+++ b/trinket.xml
@@ -16,18 +16,26 @@
       <value name="OBJECTS">
         <block type="variables_set">
           <field name="VAR">series1</field>
-            <value name="VALUE">
-              <block type="series"></block>
-            </value>
+          <value name="VALUE">
+            <block type="series">
+              <value name="COLOR">
+                <shadow type="colour_picker"></shadow>
+              </value>
+            </block>
+          </value>
         </block>
       </value>
     </block>
     <block type="variables_set">
-        <field name="VAR">series</field>
-          <value name="VALUE">
-            <block type="series"></block>
+      <field name="VAR">series</field>
+      <value name="VALUE">
+        <block type="series">
+          <value name="COLOR">
+            <shadow type="colour_picker"></shadow>
           </value>
-      </block>
+        </block>
+      </value>
+    </block>
     <block type="plot">
       <value name="X_VALUE">
         <shadow type="math_number">
@@ -231,7 +239,7 @@
     <block type="texture_picker"></block>
     <block type="scene_colour">
       <value name="COLOUR">
-        <shadow type=colour_picker></shadow>
+        <shadow type="colour_picker"></shadow>
       </value>
     </block>
   </category>


### PR DESCRIPTION
Fixes #82. Adds an open block input for a color block on the series block and defaults to color picker shadow block.
@hgclose this will require the fixes of previous test block trinkets that used the old series block like we discussed.

NOTE: Please ignore the incorrectly included commits with changes to mutator file. They were not intended for this branch and there inclusion was an oversight on my part.