### PR TITLE
43 shape mutator

### DIFF
--- a/core/flyout.js
+++ b/core/flyout.js
@@ -566,8 +566,10 @@ Blockly.Flyout.prototype.hide = function() {
  * Show and populate the flyout.
  * @param {!Array|string} xmlList List of blocks to show.
  *     Variables and procedures have a custom set of blocks.
+ * @param {number} number for scaling margin between blocks, used in mutator UI.
+ *     Default for large gap in toolbox.
  */
-Blockly.Flyout.prototype.show = function(xmlList) {
+Blockly.Flyout.prototype.show = function(xmlList, mutatorGap = 3) {
   this.hide();
   this.clearOldBlocks_();
 
@@ -596,7 +598,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       }
       blocks.push(curBlock);
       var gap = parseInt(xml.getAttribute('gap'), 10);
-      gaps.push(isNaN(gap) ? this.MARGIN * 3 : gap);
+      gaps.push(isNaN(gap) ? this.MARGIN * mutatorGap : gap);
     }
   }
 

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -216,14 +216,21 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     this.bubble_ = new Blockly.Bubble(
         /** @type {!Blockly.WorkspaceSvg} */ (this.block_.workspace),
         this.createEditor_(), this.block_.svgPath_, this.iconXY_, null, null);
+    // Get the xml of all blocks so they can be added to flyout.
     var tree = this.workspace_.options.languageTree;
+    // Get the information for the root block to made in the workspace.
     this.rootBlock_ = this.block_.decompose(this.workspace_);
+    // Get all blocks already connect to rootBlock so they can be rendered.
     var blocks = this.rootBlock_.getDescendants();
     if (tree) {
-      for (var i = 0, child; child = blocks[i]; i++) {
-        for (var j = 0, attrType; attrType = tree.childNodes[j]; j++) {
-          if (child.type == attrType.outerHTML.split('"')[1]) {
-            tree.removeChild(attrType)
+      // Check if this mutator belongs to a shape block or graph block
+      // If so, remove attribute blocks that have already composed.
+      if (this.rootBlock_.type.substr(0,14) == "vpython_create" || "display_root") {
+        for (var i = 0, child; child = blocks[i]; i++) {
+          for (var j = 0, attrType; attrType = tree.childNodes[j]; j++) {
+            if (child.type == attrType.outerHTML.split('"')[1]) {
+              tree.removeChild(attrType)
+            }
           }
         }
       }

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -64,22 +64,21 @@ Blockly.Mutator.prototype.workspaceHeight_ = 0;
  * @private
  */
 Blockly.Mutator.prototype.drawIcon_ = function(group) {
-  // Square with rounded corners.
-  Blockly.createSvgElement('rect',
+  // Cirlce container.
+  Blockly.createSvgElement('circle',
       {'class': 'blocklyIconShape',
-       'rx': '4', 'ry': '4',
-       'height': '16', 'width': '16'},
+      'r': '8.5', 'cx': '8', 'cy': '8'},
        group);
   // Horizontal Cross Bar.
   Blockly.createSvgElement('rect',
       {'class': 'blocklyIconShape',
-       'x': '3.75', 'y': '7.7',
+       'x': '3.75', 'y': '7.4',
        'height': '1', 'width': '8.5'},
        group);
   // Vertical Cross Bar.
   Blockly.createSvgElement('rect',
       {'class': 'blocklyIconShape',
-       'x': '7.4', 'y': '4',
+       'x': '7.4', 'y': '3.7',
        'height': '8.5', 'width': '1'},
        group);
 };
@@ -218,13 +217,20 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
         /** @type {!Blockly.WorkspaceSvg} */ (this.block_.workspace),
         this.createEditor_(), this.block_.svgPath_, this.iconXY_, null, null);
     var tree = this.workspace_.options.languageTree;
-    if (tree) {
-      this.workspace_.flyout_.init(this.workspace_);
-      this.workspace_.flyout_.show(tree.childNodes);
-    }
-
     this.rootBlock_ = this.block_.decompose(this.workspace_);
     var blocks = this.rootBlock_.getDescendants();
+    if (tree) {
+      for (var i = 0, child; child = blocks[i]; i++) {
+        for (var j = 0, attrType; attrType = tree.childNodes[j]; j++) {
+          if (child.type == attrType.outerHTML.split('"')[1]) {
+            tree.removeChild(attrType)
+          }
+        }
+      }
+      this.workspace_.flyout_.init(this.workspace_);
+      this.workspace_.flyout_.show(tree.childNodes, 1);
+    }
+
     for (var i = 0, child; child = blocks[i]; i++) {
       child.render();
     }

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -223,9 +223,9 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     // Get all blocks already connect to rootBlock so they can be rendered.
     var blocks = this.rootBlock_.getDescendants();
     if (tree) {
-      // Check if this mutator belongs to a shape block or graph block
+      // Check if this mutator belongs to a shape block
       // If so, remove attribute blocks that have already composed.
-      if (this.rootBlock_.type.substr(0,14) == "vpython_create" || "display_root") {
+      if (this.rootBlock_.type.substr(0,14) == "vpython_create") {
         for (var i = 0, child; child = blocks[i]; i++) {
           for (var j = 0, attrType; attrType = tree.childNodes[j]; j++) {
             if (child.type == attrType.outerHTML.split('"')[1]) {
@@ -335,6 +335,23 @@ Blockly.Mutator.prototype.workspaceChanged_ = function() {
     }
     if (block.rendered) {
       block.render();
+    }
+    // If this mutator menu belongs to a shape block, update flyout in realtime
+    if (block.type.substr(0,7) == "vpython") {
+      this.workspace_.flyout_.hide();
+      var quarkXml = goog.dom.createDom('xml');
+      for (var i = 0, quarkName; quarkName = Blockly.Blocks[block.type].mutatorName[i]; i++) {
+        quarkXml.appendChild(goog.dom.createDom('block', {'type': quarkName}));
+      }
+      var blocks = this.rootBlock_.getDescendants();
+      for (var i = 0, child; child = blocks[i]; i++) {
+        for (var j = 0, attrType; attrType = quarkXml.childNodes[j]; j++) {
+          if (child.type == attrType.outerHTML.split('"')[1]) {
+            quarkXml.removeChild(attrType)
+          }
+        }
+      }
+      this.workspace_.flyout_.show(quarkXml.childNodes, 1);
     }
     this.resizeBubble_();
     Blockly.Events.setGroup(false);


### PR DESCRIPTION
Fixes #43 
Includes the adjustment of reducing the margin space within the mutator menu for ALL mutator UI while also removing blocks from the mutator UI 'flyout' once they are dragged into the menu 'workspace' ONLY for attributes within the shape blocks.

For consideration: This was never discussed en masse, however, @codestar12 and I thought that changing the icon for the mutator symbol would also be more effective in communicating to users what type of action the menu would have after reviewing some confusion in user tests. We went with a 'plus' icon to show that attributes can be "added" to blocks that have mutators on them and @hgclose agreed it was more effective than the original gear icon which some might find confusing as well as having lots of fine detail for a small icon.