### PR TITLE
Add 'Plot' block auto selection update

### DIFF
--- a/blocks/graphs.js
+++ b/blocks/graphs.js
@@ -80,24 +80,24 @@ Blockly.Blocks['plot'] = {
   	return options;
   },
   // onchange to update current selection if it changes from a line type
-  onchange: function() {
+    onchange: function() {
     // Do nothing if block is only being dragged to avoid unnecessary calls
     if(this.workspace.isDragging())
       return;
     // Do nothing if there is no variable selected
     if (this.inputList[3].fieldRow[1] !== undefined) {
-      // Gets the currently selected variable block
+      // Gets the currently selected variable block and checks if the variable
       var selection = this.inputList[3].fieldRow[1].text_;
-      // Only continue if selection is not None (default)
-      if (!(this.workspace.getVariableUses(selection).length==0)) {
-        if (!(selection==="none")) {
-          var varBlock = this.workspace.getVariableUses(selection)[0].inputList[0].connection;
-          if (varBlock.targetConnection==null || !(varBlock.targetConnection
-                                                              .check_[0]==="Series")){
-            // Update list with top most "Series" variable
-            this.getInput("VAR").fieldRow[1].setValue(this.dynamicOptions(this)[0][0]);
-          }
-        }      
+      // If the variable in the selection no longer exists, update menu
+      if (this.workspace.getVariableUses(selection).length==0) {
+        this.getInput("VAR").fieldRow[1].setValue(this.dynamicOptions(this)[0][0]);
+      } else if (this.workspace.getVariableUses(selection)[0]) {
+        // If the selction variable still exists, check if its connection is 'Series'
+        var varBlock = this.workspace.getVariableUses(selection)[0].inputList[0].connection;
+          if (varBlock.targetConnection==null || 
+          varBlock.targetConnection.check_[0]===!("Series")) {
+            // If not 'Series', update list with top most 'Series' variable
+            this.getInput("VAR").fieldRow[1].setValue(this.dynamicOptions(this)[0][0]);}
       }
     }
   }

--- a/generators/python/graphs.js
+++ b/generators/python/graphs.js
@@ -20,7 +20,10 @@ Blockly.Python['plot'] = function(block) {
   var dropdown_name = block.getFieldValue('NAME');
   var x_value = Blockly.Python.valueToCode(block, 'X_VALUE', Blockly.Python.ORDER_ATOMIC);
   var y_value = Blockly.Python.valueToCode(block, 'Y_VALUE', Blockly.Python.ORDER_ATOMIC);
-  // TODO: Assemble Python into code variable.
+  // If variable_line is set to 'none', generate no code to avoid errors.
+  if (variable_line === "none")
+    return null;
+  // Assemble Python into code variable.
   var code = variable_line + '.plot(' + x_value + ',' + y_value + ')\n';
   return code;
 };


### PR DESCRIPTION
Fixes #93 
The actual issue with 86 being that the error reported for having the plot blocks selection to 'none' means that there are no actual 'Series' being created. Perhaps a custom error report can be created that tells the user that they must "First assign a 'Series' or 'Line' block to a variable in order to be able to plot it"