### PR TITLE
Fixes #54 math block update error when dragging.

### DIFF
--- a/blocks/math.js
+++ b/blocks/math.js
@@ -197,9 +197,6 @@ Blockly.Blocks['math_arithmetic'] = {
 
   onchange: function(e){
 
-    if(this.workspace.isDragging())
-      return;
-
     var newVec = this.vectorPositions();
     if(this.vecPos != newVec){
       this.vecPos = newVec;


### PR DESCRIPTION
Allows check of a vector block connection/disconnection while dragging within the onChange function.
NOTE: If efficiency becomes a problem across platforms this and other function calls similar to it may be suspect.